### PR TITLE
Update: improve close async

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dat-encoding": "^5.0.1",
     "dat-swarm-defaults": "^1.0.2",
     "duplexify": "^4.0.0",
+    "end-of-stream": "^1.4.4",
     "hypercore-protocol": "^7.6.0",
     "hyperswarm": "^2.6.0",
     "pump": "^3.0.0"


### PR DESCRIPTION
This PR improves the way async is handled when `closing`.

Note: this is breaking on node8 due to lack of `timeout.refresh` method (was added on node 10) but I guess we can discard node 8 from travis.

Thanks @tinchoz49 for his help on this.